### PR TITLE
patch process_template_response

### DIFF
--- a/django_prometheus/middleware.py
+++ b/django_prometheus/middleware.py
@@ -144,8 +144,9 @@ class PrometheusAfterMiddleware(MiddlewareMixin):
                 name, transport, method).inc()
 
     def process_template_response(self, request, response):
-        responses_by_templatename.labels(str(
-            response.template_name)).inc()
+        if hasattr(response, 'template_name'):
+            responses_by_templatename.labels(str(
+                response.template_name)).inc()
         return response
 
     def process_response(self, request, response):


### PR DESCRIPTION
When trying to use caching with DRF we get ```AttributeError: 'Response' object has no attribute 'template_name'```error  as reported here too https://github.com/korfuri/django-prometheus/issues/54
This tries to patch process_template_response() to prevent the issue